### PR TITLE
Fix password reset

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -4,13 +4,20 @@ class Users::PasswordsController < Devise::PasswordsController
   def update
     tos_accepted = resource_params[:tos_accepted]
 
-    self.resource = User.find_by(resource_params[:email])
+    # found in devise-invitable's #reset_password_by_token method
+    original_token       = resource_params[:reset_password_token]
+    reset_password_token = Devise.token_generator.digest(self, :reset_password_token, original_token)
+    # find *without* initializing with an error
+    self.resource = User.find_by(reset_password_token: reset_password_token)
+
     if tos_accepted == "1"
       resource.tos_accepted = tos_accepted
       resource.save
       super
     else
-      respond_with resource, location: edit_user_password_path(reset_password_token: resource_params[:reset_password_token])
+      flash[:alert] = 'Terms of service must be accepted.'
+      respond_with resource,
+        location: edit_user_password_path(reset_password_token: resource_params[:reset_password_token])
     end
   end
 end

--- a/app/helpers/charges_helper.rb
+++ b/app/helpers/charges_helper.rb
@@ -1,2 +1,0 @@
-module ChargesHelper
-end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,0 @@
-module UsersHelper
-end


### PR DESCRIPTION
`User.find_by(resource_params[:email])` is always `User.find_by(nil)` when submitting params via the passwords#edit form.

Apparently `User.find_by(nil)` actually finds an instance of User!