### PR TITLE
Add custom labels

### DIFF
--- a/app/assets/javascripts/encounters.js
+++ b/app/assets/javascripts/encounters.js
@@ -2,9 +2,16 @@
 // # All this logic will automatically be available in application.js.
 // # You can use CoffeeScript in this file: http://coffeescript.org/
 
-var encounter_types = ['adult_inpatient', 'adult_ed', 'adult_icu', 'adult_inpatient_surgery',
-                       'pediatric_inpatient', 'pediatric_newborn', 'pediatric_ed',
-                       'continuity_inpatient', 'continuity_external'];
+var encounter_types = [];
+
+// TODO: How can this behavior be run on page ready or load instead of
+// called by event handler functions below?
+function parseEncounterLabels() {
+  if (!encounter_types.length) {
+    encounter_types = $('.encounter_type_button');
+    encounter_types = encounter_types.map(function(index, element) { return element.id; });
+  }
+}
 
 function setEncounteredOn() {
   var date = $('#date').val();
@@ -14,6 +21,7 @@ function setEncounteredOn() {
 }
 
 function resetEncounters() {
+  parseEncounterLabels();
   for (i = 0; i < encounter_types.length; i++) {
     var encounter_type = encounter_types[i];
     $("#" + encounter_type).html(0);
@@ -25,6 +33,7 @@ function resetEncounters() {
 }
 
 function incrementEncounterType(encounter_type) {
+  parseEncounterLabels();
   console.log(encounter_type);
   current_value = parseInt( $('#' + encounter_type).text() );
   console.log(current_value);
@@ -40,6 +49,7 @@ function incrementEncounterType(encounter_type) {
 }
 
 function calcTotal() {
+  parseEncounterLabels();
   var total =  parseInt($('#encounter_types_' + encounter_types[0]).val()) +
                parseInt($('#encounter_types_' + encounter_types[1]).val()) +
                parseInt($('#encounter_types_' + encounter_types[2]).val()) +

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -1,4 +1,6 @@
 class EncountersController < ApplicationController
+  include EncountersHelper
+
   before_action :authenticate_user!
   before_action :set_encounter, only: [:show, :edit, :update, :destroy]
   # GET /encounters
@@ -44,11 +46,11 @@ class EncountersController < ApplicationController
   # POST /encounters
   # POST /encounters.json
   def create
-    redirect_to(encounters_path, notice: 'You cannot delete encounters!') and return if current_user.admin?
+    redirect_to(encounters_path, notice: 'You cannot create encounters!') and return if current_user.admin?
     total = 0
     begin
       ActiveRecord::Base.transaction do
-        encounter_types.each do |type, number|
+        encounter_params.each do |type, number|
           total += number.to_i
           number.to_i.times {Encounter.create!(encounter_type: type.to_s.humanize(capitalize: false), encountered_on: encountered_on, user: current_user)}
         end
@@ -84,19 +86,11 @@ class EncountersController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def encounter_params
-      params.require(:encounter).permit(:encounter_type)
+      params.require(:encounter_types).permit(encounter_types.map{|str| str.to_sym})
     end
 
     # Require that params[:encountered_on] is not empty and return the value
     def encountered_on
       params.require(:encountered_on)
-    end
-
-    def encounter_types
-      params.require(:encounter_types).permit(
-        :adult_inpatient, :adult_ed, :adult_icu, :adult_inpatient_surgery,
-        :pediatric_inpatient, :pediatric_newborn, :pediatric_ed,
-        :continuity_inpatient, :continuity_external
-      )
     end
 end

--- a/app/helpers/encounters_helper.rb
+++ b/app/helpers/encounters_helper.rb
@@ -1,2 +1,83 @@
 module EncountersHelper
+
+  # These methods choose the set of encounter_type that are used to
+  # creat the new form's hidden inputs and the value that will be submitted
+  # in the hidden inputs.
+
+  # Note: The _encounter_types_ return values can be produced by mapping the
+  # _labels_ arrays with `labels.remove(' ').underscore`.
+
+  def encounter_types
+    if current_user.residency == ENV['CUSTOM_ENCOUNTER_TYPES_AND_LABELS_1']
+      custom_encounters_types_1
+    else
+      default_encounters_types
+    end
+  end
+
+  def default_encounters_types
+    [
+      'adult_inpatient',
+      'adult_ed',
+      'adult_icu',
+      'adult_inpatient_surgery',
+      'pediatric_inpatient',
+      'pediatric_newborn',
+      'pediatric_ed',
+      'continuity_inpatient',
+      'continuity_external'
+    ]
+  end
+
+  def custom_encounters_types_1
+    [
+      'adult_inpatient',
+      'adult_icu',
+      'obstetrics_vaginal_deliveries',
+      'older_adults_outpatient',
+      'pediatric_outpatient',
+      'pediatric_inpatient',
+      'pediatric_newborn',
+      'pediatric_ed',
+      'women’s_health_outpatient'
+    ]
+  end
+
+  # These methods choose the set of labels to display for the
+  # encounters#new view, based on the residency's name (stored in ENV).
+  def display_labels
+    if current_user.residency == ENV['CUSTOM_ENCOUNTER_TYPES_AND_LABELS_1']
+      custom_display_labels_1
+    else
+      default_display_labels
+    end
+  end
+
+  def default_display_labels
+    [
+      "Adult Inpatient",
+      "Adult ED",
+      "Adult ICU",
+      "Adult Inpatient Surgery",
+      "Pediatric Inpatient",
+      "Pediatric Newborn",
+      "Pediatric ED",
+      "Continuity Inpatient",
+      "Continuity External"
+    ]
+  end
+
+  def custom_display_labels_1
+    [
+      'Adult Inpatient',
+      'Adult ICU',
+      'Obstetrics Vaginal Deliveries',
+      'OlderAdults Outpatient',
+      'Pediatric Outpatient',
+      'Pediatric Inpatient',
+      'Pediatric Newborn',
+      'Pediatric ED',
+      'Women’sHealth Outpatient'
+    ]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,11 @@ class User < ActiveRecord::Base
 
   has_many :encounters, dependent: :destroy
   has_many :invitations, :class_name => 'User', :as => :invited_by
-  after_invitation_accepted :update_inviter_subscription_quantity, :delete_all_customer_subscriptions, :change_role_to_resident, :set_active_until
+  after_invitation_accepted :update_inviter_subscription_quantity,
+                            :delete_all_customer_subscriptions,
+                            :change_role_to_resident,
+                            :set_active_until,
+                            :set_residency
 
   before_create :set_default_role, :set_active_until
   before_save :set_name
@@ -68,6 +72,13 @@ class User < ActiveRecord::Base
     def set_active_until
       if invited_by_id?
         self.active_until = invited_by.active_until
+      end
+    end
+
+    def set_residency
+      if invited_by_id?
+        self.residency = invited_by.residency
+        self.save
       end
     end
 

--- a/app/views/encounters/_encounter_types.html.erb
+++ b/app/views/encounters/_encounter_types.html.erb
@@ -1,15 +1,11 @@
-<% display_labels = ["Adult Inpatient", "Adult ED", "Adult ICU", "Adult Inpatient Surgery",
-                    "Pediatric Inpatient", "Pediatric Newborn", "Pediatric ED",
-                    "Continuity Inpatient", "Continuity External"] %>
-
 <% display_labels.each_with_index do |display_label, i| %>
   <%= content_tag :div, class: "#{i == 0 ? 'lineitem_end' : 'lineitem'}" do %>
     <div class="linelabel blockFloat">
-      <strong><%= "#{display_label.split.first}:" %></strong>
+      <strong><%= "#{display_label.split.first.titleize}:" %></strong>
       <%= display_label.split.slice(1..-1).join(' ') %>
     </div>
     <%= link_to '#', {onclick: "incrementEncounterType('#{encounter_types[i]}')"} do %>
-      <%= content_tag :div, 0, id: encounter_types[i], class: "linenumber gradient_light blockFloatRight" %>
+      <%= content_tag :div, 0, id: encounter_types[i], class: "encounter_type_button linenumber gradient_light blockFloatRight" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/encounters/new.html.erb
+++ b/app/views/encounters/new.html.erb
@@ -35,9 +35,6 @@
     </div><!-- /wrap_section_narrow -->
 
     <div class="wrap_section_narrow">
-      <% encounter_types = ['adult_inpatient', 'adult_ed', 'adult_icu', 'adult_inpatient_surgery',
-         'pediatric_inpatient', 'pediatric_newborn', 'pediatric_ed',
-         'continuity_inpatient', 'continuity_external'] %>
       <%= render partial: 'encounter_types', locals: {encounter_types: encounter_types} %>
       <%= render partial: 'form', locals: {encounter_types: encounter_types} %>
     </div><!-- /wrap_section_narrow -->

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+
+  setup do
+    @admin = users(:admin)
+  end
+
   test "the truth" do
     assert true
     assert_not false
@@ -56,7 +61,7 @@ class UserTest < ActiveSupport::TestCase
            Stripe::Customer.retrieve('cus_0000000').subscriptions.first.quantity
   end
 
-  test "change role to resident" do
+  test "when a user accepts an invitation, then change role to resident" do
     admin = User.create!(
       email: 'admin-to-resident@example.com',
       password: 'password',
@@ -73,5 +78,15 @@ class UserTest < ActiveSupport::TestCase
       password_confirmation: 'password')
     assert_equal 'admin-to-resident@example.com', admin.email
     assert_equal 'resident', admin.role
+  end
+
+  test "when a user accepts an invitation set residency to inviter s residency" do
+    resident = User.invite!({email: 'invited-resident@example.com'}, users(:admin))
+    resident = User.accept_invitation!(
+      invitation_token: resident.raw_invitation_token,
+      password: 'password',
+      password_confirmation: 'password',
+      tos_accepted: true)
+    assert_equal 'Test Residency', resident.residency
   end
 end


### PR DESCRIPTION
This PR adds the ability to display a custom set of labels and their corresponding values in the appropriate database column.  Since there are currently only one set of custom labels, this implementation chooses the labels based on an ENV var, through helper methods that return arrays.

A more flexible and robust iteration should be implemented, storing this custom data in a database table.